### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release-please-config.yml
+++ b/.github/workflows/release-please-config.yml
@@ -5,6 +5,9 @@ on:
 name: release-please
 jobs:
   release-please:
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: google-github-actions/release-please-action@v4


### PR DESCRIPTION
Potential fix for [https://github.com/RalphHightower/NANPATelephoneFormatDetection/security/code-scanning/5](https://github.com/RalphHightower/NANPATelephoneFormatDetection/security/code-scanning/5)

To address this issue, an explicit `permissions:` block should be added to the workflow—either at the top level (before `jobs:`) or scoped within the relevant job. For the "release-please" workflow, the required minimum permissions are typically `contents: write` (to create tags/releases) and `pull-requests: write` (to create/update release pull requests). These should be set in the `permissions` block for the `release-please` job. The change is to edit `.github/workflows/release-please-config.yml` by adding the following under the job definition (`jobs: release-please:`) before `runs-on: ubuntu-latest`. No imports or special definitions are required. Only the YAML block needs to be updated.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
